### PR TITLE
Add beforeRenderPageHandler

### DIFF
--- a/packages/vike-node/README.md
+++ b/packages/vike-node/README.md
@@ -142,6 +142,37 @@ app.use(
 )
 ```
 
+## beforeRenderPageHandler middleware:
+
+This middleware is useful for cases like i18n : https://vike.dev/i18n.
+For example when we want to redirect the user using the 'Accept-Language' header.
+
+```js
+app.use(
+  vike({
+    onBeforeRenderPage(req, res) {
+      const isLocaleInPathname = ...
+      const acceptLanguageHeaderExists = req.headers.has("Accept-Language")
+      const url = new URL(req.url)
+
+      if (!isLocaleInPathname && acceptLanguageHeaderExists) {
+        const acceptLanguageHeader = req.headers.get("Accept-Language");
+        const locale = ...
+
+        const { pathname, search, hash } = url;
+        const pathWithoutOrigin = `${pathname}${search}${hash}`;
+
+        res.statusCode = 302;
+        res.setHeader('Location', `/${locale}${pathWithoutOrigin}`)
+        return true;
+      }
+
+      return false;
+    }
+  })
+)
+```
+
 ## Framework examples:
 
 `vike-node` includes middlewares for the most popular web frameworks:

--- a/packages/vike-node/README.md
+++ b/packages/vike-node/README.md
@@ -150,7 +150,7 @@ For example when we want to redirect the user using the 'Accept-Language' header
 ```js
 app.use(
   vike({
-    onBeforeRenderPage(req, res) {
+    beforeRenderPageHandler(req, res) {
       const isLocaleInPathname = ...
       const acceptLanguageHeaderExists = req.headers.has("Accept-Language")
       const url = new URL(req.url)

--- a/packages/vike-node/src/runtime/handler.ts
+++ b/packages/vike-node/src/runtime/handler.ts
@@ -52,6 +52,16 @@ export function createHandler<PlatformRequest>(options: VikeOptions<PlatformRequ
       }
     }
 
+    if (options.onBeforeRenderPage) {
+      const handled = await options.onBeforeRenderPage(platformRequest, res)
+      if (handled) {
+        res.emit('finish')
+        return new Promise<boolean>((resolve) => {
+          res.once('finish', () => resolve(true))
+        })
+      }
+    }
+
     const handled = await renderPageAndRespond(req, res, platformRequest)
     if (handled) return true
     next?.()
@@ -63,7 +73,7 @@ export function createHandler<PlatformRequest>(options: VikeOptions<PlatformRequ
       const { default: shrinkRay } = await import('@nitedani/shrink-ray-current')
       compressMiddleware = shrinkRay({ cacheSize: shouldCache ? '128mB' : false }) as ConnectMiddleware
     }
-    compressMiddleware(req, res, () => {})
+    compressMiddleware(req, res, () => { })
   }
 
   async function serveStaticFiles(

--- a/packages/vike-node/src/runtime/handler.ts
+++ b/packages/vike-node/src/runtime/handler.ts
@@ -52,8 +52,8 @@ export function createHandler<PlatformRequest>(options: VikeOptions<PlatformRequ
       }
     }
 
-    if (options.onBeforeRenderPage) {
-      const handled = await options.onBeforeRenderPage(platformRequest, res)
+    if (options.beforeRenderPageHandler) {
+      const handled = await options.beforeRenderPageHandler(platformRequest, res)
       if (handled) {
         res.emit('finish')
         return new Promise<boolean>((resolve) => {

--- a/packages/vike-node/src/runtime/handler.ts
+++ b/packages/vike-node/src/runtime/handler.ts
@@ -73,7 +73,7 @@ export function createHandler<PlatformRequest>(options: VikeOptions<PlatformRequ
       const { default: shrinkRay } = await import('@nitedani/shrink-ray-current')
       compressMiddleware = shrinkRay({ cacheSize: shouldCache ? '128mB' : false }) as ConnectMiddleware
     }
-    compressMiddleware(req, res, () => { })
+    compressMiddleware(req, res, () => {})
   }
 
   async function serveStaticFiles(

--- a/packages/vike-node/src/runtime/types.ts
+++ b/packages/vike-node/src/runtime/types.ts
@@ -8,7 +8,7 @@ export type VikeOptions<PlatformRequest = null> = {
   compress?: boolean | 'static'
   static?: boolean | string | { root?: string; cache?: boolean }
   onError?: (err: unknown) => void
-  onBeforeRenderPage?: (req: PlatformRequest, res: ServerResponse) => boolean | Promise<boolean>
+  beforeRenderPageHandler?: (req: PlatformRequest, res: ServerResponse) => boolean | Promise<boolean>
 }
 export type ConnectMiddleware<
   PlatformRequest extends IncomingMessage = IncomingMessage,

--- a/packages/vike-node/src/runtime/types.ts
+++ b/packages/vike-node/src/runtime/types.ts
@@ -8,6 +8,7 @@ export type VikeOptions<PlatformRequest = null> = {
   compress?: boolean | 'static'
   static?: boolean | string | { root?: string; cache?: boolean }
   onError?: (err: unknown) => void
+  onBeforeRenderPage?: (req: PlatformRequest, res: ServerResponse) => boolean | Promise<boolean>
 }
 export type ConnectMiddleware<
   PlatformRequest extends IncomingMessage = IncomingMessage,


### PR DESCRIPTION
This middleware is useful for cases like i18n : https://vike.dev/i18n.
For example when we want to redirect the user using the 'Accept-Language' header.

We need the middleware to be placed after static files and vite dev server because we don't want to redirect those files.