### PR TITLE
fix: vike-handler type and useless code

### DIFF
--- a/packages/vike-node/src/runtime/vike-handler.ts
+++ b/packages/vike-node/src/runtime/vike-handler.ts
@@ -30,10 +30,6 @@ async function renderPage<PlatformRequest>({
     options.onError?.(pageContext.errorWhileRendering)
   }
 
-  if (!pageContext.httpResponse) {
-    return null
-  }
-
   return pageContext.httpResponse
 }
 

--- a/packages/vike-node/src/runtime/vike-handler.ts
+++ b/packages/vike-node/src/runtime/vike-handler.ts
@@ -16,7 +16,7 @@ async function renderPage<PlatformRequest>({
   options: VikeOptions<PlatformRequest>
   platformRequest: PlatformRequest
 }): Promise<VikeHttpResponse> {
-  function getPageContext(platformRequest: PlatformRequest): Record<string, any> {
+  async function getPageContext(platformRequest: PlatformRequest): Promise<Record<string, any>> {
     return typeof options.pageContext === 'function' ? options.pageContext(platformRequest) : options.pageContext ?? {}
   }
 


### PR DESCRIPTION
- add _async_ type to `getPageContext`
- `VikeHttpResponse` and `pageContext.httpResponse` are both `HttpResponse | null`: remove useless check of `pageContext.httpResponse` that return _null_ if it's falsy otherwise _HttpResponse_