### PR TITLE
feat: init uWebSocket.js support

### DIFF
--- a/packages/vike-node/src/runtime/frameworks/uws.ts
+++ b/packages/vike-node/src/runtime/frameworks/uws.ts
@@ -1,0 +1,36 @@
+export { vike }
+
+import type { TemplatedApp, HttpRequest } from 'uWebSockets.js'
+import { createHandler } from '../handler-web-and-node-uws.js'
+import type { PlatformRequestUws, VikeOptions } from '../types.js'
+
+/**
+ * Creates an uWebSockets.js plugin to handle Vike requests.
+ *
+ * @param {VikeOptions} [options] - Configuration options for Vike.
+ *
+ * @returns {TemplatedApp} An uWebSockets.js plugin that handles all GET requests and processes them with Vike.
+ *
+ * @description
+ * The plugin:
+ * 1. Set up a catch-all GET route handler that processes requests using Vike's handler.
+ * 2. Catch internal errors.
+ *
+ * @example
+ * ```js
+ * import { App } from 'uWebSockets.js'
+ * import { vike } from 'vike-node/uws'
+ *
+ * const app = vike(App())
+ * app.listen(3000)
+ * ```
+ */
+function vike(app: TemplatedApp, options?: VikeOptions<HttpRequest>): TemplatedApp {
+  const handler = createHandler(options)
+  return app.get('*', (response, request) => 
+    handler({ response, request, platformRequest: request as PlatformRequestUws }).catch((error: Error) => {
+        console.error(error)
+        response.writeStatus('500').end('Internal Server Error: ' + error.message)
+    })
+  )
+}

--- a/packages/vike-node/src/runtime/handler-web-and-node-uws.ts
+++ b/packages/vike-node/src/runtime/handler-web-and-node-uws.ts
@@ -1,0 +1,53 @@
+import type { HttpRequest, HttpResponse } from 'uWebSockets.js'
+import { isNodeLike } from '../utils/isNodeLike.js'
+import { connectToWeb } from './adapters/connectToWeb.js'
+import { createHandler as createHandlerNode } from './handler-node-only-uws.js'
+import { createHandler as createHandlerWeb } from'./handler-web-only-uws.js'
+import type { PlatformRequestUws, VikeOptions } from './types.js'
+
+const getHeaders = (req: HttpRequest): [string, string][] => {
+  const headers: [string, string][] = []
+
+  req.forEach((key, value) => {
+    headers.push([key, value])
+  })
+
+  return headers
+}
+
+type Handler<PlatformRequestUws> = (params: {
+  response: HttpResponse
+  request: HttpRequest
+  platformRequest: PlatformRequestUws
+}) => Promise<void>
+
+export function createHandler<HttpRequest>(options: VikeOptions<HttpRequest> = {}): Handler<PlatformRequestUws> {
+  return async function handler({ response, request, platformRequest }) {
+    response.onAborted(() => {
+      response.isAborted = true
+    })
+
+    if (request.getMethod() !== 'get') {
+      response.writeStatus('405').end()
+      return
+    }
+
+    platformRequest.url = request.getUrl()
+    platformRequest.headers = getHeaders(request)
+
+    if (await isNodeLike()) {
+      const nodeOnlyHandler = createHandlerNode(options)
+      const nodeHandler: Handler<PlatformRequestUws> = ({ request, platformRequest }) => {
+        const connectedHandler = connectToWeb((req, res) =>
+          nodeOnlyHandler({ req, res, platformRequest })
+        )
+        return connectedHandler(request)
+      }
+
+      await nodeHandler({ request, platformRequest })
+    } else {
+      const webHandler: Handler<PlatformRequestUws> = createHandlerWeb(options)
+      await webHandler({ platformRequest })
+    }
+  }
+}

--- a/packages/vike-node/src/runtime/handler-web-only-uws.ts
+++ b/packages/vike-node/src/runtime/handler-web-only-uws.ts
@@ -1,0 +1,11 @@
+import type { HttpRequest } from 'uWebSockets.js'
+import type { PlatformRequestUws, VikeOptions } from './types.js'
+import { renderPageWebUws } from './vike-handler-uws.js'
+
+export function createHandler(options: VikeOptions<HttpRequest> = {}): Promise<void> {
+  return async function handler({ platformRequest }: {
+    platformRequest: PlatformRequestUws
+  }) {
+    await renderPageWebUws({ url: platformRequest.url, headers: platformRequest.headers, platformRequest, options })
+  }
+}

--- a/packages/vike-node/src/runtime/types.ts
+++ b/packages/vike-node/src/runtime/types.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'http'
+import type { HttpRequest, HttpResponse } from 'uWebSockets.js'
 
 export type HeadersProvided = Record<string, string | string[] | undefined> | Headers
 export type VikeHttpResponse = Awaited<ReturnType<typeof import('vike/server').renderPage>>['httpResponse']
@@ -13,4 +14,10 @@ export type ConnectMiddleware<
   PlatformRequest extends IncomingMessage = IncomingMessage,
   PlatformResponse extends ServerResponse = ServerResponse
 > = (req: PlatformRequest, res: PlatformResponse, next: NextFunction) => void
+export type ConnectMiddlewareUws = (req: HttpRequest, res: HttpResponse) => void
 export type WebHandler = (request: Request) => Response | undefined | Promise<Response | undefined>
+export type WebHandlerUws = (request: HttpRequest) => Promise<void>
+export type PlatformRequestUws = HttpRequest & {
+  url: string
+  headers: [string, string][]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         version: 4.28.1
       h3:
         specifier: ^1.12.0
-        version: 1.12.0
+        version: 1.12.0(uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700)
       hono:
         specifier: ^4.5.5
         version: 4.5.5
@@ -255,7 +255,7 @@ importers:
         version: 4.28.1
       h3:
         specifier: ^1.12.0
-        version: 1.12.0
+        version: 1.12.0(uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700)
       hono:
         specifier: ^4.5.5
         version: 4.5.5
@@ -277,6 +277,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      uWebSockets.js:
+        specifier: github:uNetworking/uWebSockets.js#v20.49.0
+        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700
       vike:
         specifier: ^0.4.193
         version: 0.4.193(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.0(@types/node@20.14.15))
@@ -1863,6 +1866,7 @@ packages:
 
   crossws@0.2.4:
     resolution: {integrity: sha512-DAxroI2uSOgUKLz00NX6A8U/8EE3SZHmIND+10jkVSaypvyt57J5JEOxAQOL6lQxyzi/wZbTIwssU1uy69h5Vg==}
+    version: 0.2.4
     peerDependencies:
       uWebSockets.js: '*'
     peerDependenciesMeta:
@@ -2180,6 +2184,7 @@ packages:
 
   h3@1.12.0:
     resolution: {integrity: sha512-Zi/CcNeWBXDrFNlV0hUBJQR9F7a96RjMeAZweW/ZWkR9fuXrMcvKnSA63f/zZ9l0GgQOZDVHGvXivNN9PWOwhA==}
+    version: 1.12.0
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -3039,6 +3044,10 @@ packages:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700}
+    version: 20.49.0
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -4542,7 +4551,9 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  crossws@0.2.4: {}
+  crossws@0.2.4(uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700):
+    optionalDependencies:
+      uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700
 
   csstype@3.1.3: {}
 
@@ -4959,10 +4970,10 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  h3@1.12.0:
+  h3@1.12.0(uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700):
     dependencies:
       cookie-es: 1.2.2
-      crossws: 0.2.4
+      crossws: 0.2.4(uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700)
       defu: 6.1.4
       destr: 2.0.3
       iron-webcrypto: 1.2.1
@@ -5787,6 +5798,8 @@ snapshots:
       mime-types: 2.1.35
 
   typescript@5.5.4: {}
+
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/442087c0a01bf146acb7386910739ec81df06700: {}
 
   ufo@1.5.4: {}
 

--- a/test/vike-node/package.json
+++ b/test/vike-node/package.json
@@ -26,6 +26,7 @@
     "sharp": "^0.33.4",
     "telefunc": "^0.1.76",
     "typescript": "^5.5.4",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.49.0",
     "vike": "^0.4.193",
     "vike-node": "link:../../packages/vike-node",
     "vite": "^5.4.0"

--- a/test/vike-node/vite.config.ts
+++ b/test/vike-node/vite.config.ts
@@ -13,5 +13,7 @@ export default {
     telefunc()
   ],
   // Make test more interesting: avoid vite-plugin-server-entry from [finding the server entry by searching for the dist/ directory](https://github.com/brillout/vite-plugin-server-entry/blob/240f59b4849a3fdfd84448117a3aaf4fbe95a8a0/src/runtime/crawlServerEntry.ts)
-  build: { outDir: 'build' }
+  build: { outDir: 'build' },
+  // Disable CORS for the test of uWebSockets.js where the cors middleware isn't compatible with uWebSockets.js
+  server: { cors: false }
 }


### PR DESCRIPTION
### Changes
- disabled `cors` middleware (enabled by default) in Vite Dev Server: `cors` middleware, used by Vite, uses isn't compatible with _responde_ and _request_ as _Request_, _IncomingMessage_, _ServerResponse_ of Node.js

Fix #20