### PR TITLE
Fix `pagecontext` function

### DIFF
--- a/packages/vike-node/README.md
+++ b/packages/vike-node/README.md
@@ -251,11 +251,13 @@ function startServer() {
 You can define custom [pageContext](https://vike.dev/pageContext) properties:
 
 ```ts
+import { type RuntimeAdapter } from 'vike-node/express';
+
 app.use(
   vike({
-    pageContext(req: IncomingMessage) {
+    pageContext(runtime: RuntimeAdapter) {
       return {
-        user: req.user
+        user: runtime.req.user
       }
     }
   })

--- a/packages/vike-node/package.json
+++ b/packages/vike-node/package.json
@@ -79,8 +79,8 @@
   "dependencies": {
     "@brillout/picocolors": "^1.0.14",
     "@nitedani/shrink-ray-current": "^4.3.0",
-    "@universal-middleware/core": "^0.3.2",
-    "@universal-middleware/compress": "^0.2.6",
+    "@universal-middleware/core": "^0.3.3",
+    "@universal-middleware/compress": "^0.2.8",
     "@vercel/nft": "^0.26.5",
     "esbuild": "^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",
     "resolve-from": "^5.0.0",
@@ -100,7 +100,7 @@
     "hono": "^4.6.3",
     "tsup": "^8.3.0",
     "typescript": "^5.5.4",
-    "universal-middleware": "^0.5.3",
+    "universal-middleware": "^0.5.5",
     "vike": "^0.4.198",
     "vite": "^6.0.2"
   },

--- a/packages/vike-node/src/runtime/types.ts
+++ b/packages/vike-node/src/runtime/types.ts
@@ -1,14 +1,19 @@
 import type { IncomingMessage, ServerResponse } from 'http'
+import type { RuntimeAdapterTarget } from '@universal-middleware/core'
 
 export type HeadersProvided = Record<string, string | string[] | undefined> | Headers
 export type VikeHttpResponse = Awaited<ReturnType<typeof import('vike/server').renderPage>>['httpResponse']
 export type NextFunction = (err?: unknown) => void
-export type VikeOptions<PlatformRequest = unknown> = {
-  pageContext?: ((req: PlatformRequest) => Record<string, any> | Promise<Record<string, any>>) | Record<string, any>
+
+export type VikeOptions<T = unknown> = {
+  pageContext?:
+    | ((req: RuntimeAdapterTarget<T>) => Record<string, any> | Promise<Record<string, any>>)
+    | Record<string, any>
   compress?: boolean | 'static'
   static?: boolean | string | { root?: string; cache?: boolean }
   onError?: (err: unknown) => void
 }
+
 export type ConnectMiddleware<
   PlatformRequest extends IncomingMessage = IncomingMessage,
   PlatformResponse extends ServerResponse = ServerResponse

--- a/packages/vike-node/src/runtime/vike-handler.ts
+++ b/packages/vike-node/src/runtime/vike-handler.ts
@@ -1,6 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import compressMiddlewareFactory from '@universal-middleware/compress'
-import { type Get, type UniversalHandler, type UniversalMiddleware } from '@universal-middleware/core'
+import {
+  type Get,
+  type RuntimeAdapter,
+  type UniversalHandler,
+  type UniversalMiddleware
+} from '@universal-middleware/core'
 import { renderPage as _renderPage } from 'vike/server'
 import { assert } from '../utils/assert.js'
 import { isVercel } from '../utils/isVercel.js'
@@ -9,7 +14,7 @@ import { globalStore } from './globalStore.js'
 import type { ConnectMiddleware, VikeHttpResponse, VikeOptions } from './types.js'
 import { parseHeaders } from './utils/header-utils.js'
 
-async function renderPage({
+async function renderPage<T extends RuntimeAdapter>({
   url,
   headers,
   runtimeRequest,
@@ -17,7 +22,7 @@ async function renderPage({
 }: {
   url: string
   headers: [string, string][]
-  runtimeRequest: unknown
+  runtimeRequest: T
   options: VikeOptions
 }): Promise<VikeHttpResponse> {
   let pageContextInit: Record<string, any> = {}

--- a/packages/vike-node/src/runtime/vike-handler.ts
+++ b/packages/vike-node/src/runtime/vike-handler.ts
@@ -23,13 +23,13 @@ async function renderPage<T extends RuntimeAdapter>({
   url: string
   headers: [string, string][]
   runtimeRequest: T
-  options: VikeOptions
+  options: VikeOptions & { pageContextUniversal?: Record<string, any> }
 }): Promise<VikeHttpResponse> {
-  let pageContextInit: Record<string, any> = {}
+  let pageContextInit: Record<string, any> = options.pageContextUniversal ?? {}
   if (typeof options?.pageContext === 'function') {
-    pageContextInit = await options.pageContext(runtimeRequest)
+    Object.assign(pageContextInit, await options.pageContext(runtimeRequest))
   } else if (options?.pageContext) {
-    pageContextInit = options.pageContext
+    Object.assign(pageContextInit, options.pageContext)
   }
 
   const pageContext = await _renderPage({
@@ -102,10 +102,8 @@ export const renderPageHandler = ((options?) => async (request, context, runtime
     runtimeRequest: runtime.adapter in runtime ? (runtime as any)[runtime.adapter] : request,
     options: {
       ...options,
-      pageContext: {
-        ...pageContextInit,
-        ...options?.pageContext
-      }
+      pageContextUniversal: pageContextInit,
+      pageContext: options?.pageContext
     }
   })
 

--- a/packages/vike-node/src/runtime/vike-handler.ts
+++ b/packages/vike-node/src/runtime/vike-handler.ts
@@ -99,7 +99,7 @@ export const renderPageHandler = ((options?) => async (request, context, runtime
   const response = await renderPage({
     url: request.url,
     headers: parseHeaders(request.headers),
-    runtimeRequest: runtime.adapter in runtime ? (runtime as any)[runtime.adapter] : request,
+    runtimeRequest: runtime,
     options: {
       ...options,
       pageContextUniversal: pageContextInit,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,11 +173,11 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       '@universal-middleware/compress':
-        specifier: ^0.2.6
-        version: 0.2.6
+        specifier: ^0.2.8
+        version: 0.2.8
       '@universal-middleware/core':
-        specifier: ^0.3.2
-        version: 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+        specifier: ^0.3.3
+        version: 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
       '@vercel/nft':
         specifier: ^0.26.5
         version: 0.26.5
@@ -219,8 +219,8 @@ importers:
         specifier: ^5.5.4
         version: 5.7.2
       universal-middleware:
-        specifier: ^0.5.3
-        version: 0.5.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(esbuild@0.24.0)(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)(vite@6.0.2(@types/node@20.17.7))
+        specifier: ^0.5.5
+        version: 0.5.5(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(esbuild@0.24.0)(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)(vite@6.0.2(@types/node@20.17.7))
       vike:
         specifier: ^0.4.198
         version: 0.4.204(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@20.17.7))
@@ -1178,14 +1178,14 @@ packages:
   '@types/serve-static@1.15.7':
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
 
-  '@universal-middleware/cloudflare@0.3.2':
-    resolution: {integrity: sha512-2kZdb19HXdZ51kr4ua6tQYPpGksgpUS+HVveTOHvA0r6E1MLyQ087N4LNNOxnqoxA6WjEFvdhKJmFbeiW5S6ew==}
+  '@universal-middleware/cloudflare@0.3.3':
+    resolution: {integrity: sha512-CxindLBsxPTcppz08OtkWCi9gPEucU4ROV36J1j5qp0g30/4oAd6Dj2SRYyHCGdm7LDrs+8mz8spnchxsyj3Iw==}
 
-  '@universal-middleware/compress@0.2.6':
-    resolution: {integrity: sha512-Fdv+SNVlVmIrq4biC4+SKM6gCGjxXVqZ1CVTEq5W6xjKeSDIN2kBkDlpGtBjJRbGAEvQQ4JbejnPFIevotsMbw==}
+  '@universal-middleware/compress@0.2.8':
+    resolution: {integrity: sha512-CJoEX9KWZjt1aH9HCyi1t5Lcvpcv2E//jnnoI5woEjxSdWVIKMGMawsQ8P825spfuKuyyneLyC/zcrZU8VvgQQ==}
 
-  '@universal-middleware/core@0.3.2':
-    resolution: {integrity: sha512-f2iMeagmyluwUXRl9g8g7O6BvaPKtC5TFC+XijrE26U96M5sfYmrvvfUJ+25/UR9f9saPshzxTKaQDrSyf4+Qw==}
+  '@universal-middleware/core@0.3.3':
+    resolution: {integrity: sha512-wh4qRSeRHp3ZvyDJQjSY9z42DUObAHfhhVdegR0YaUxPJpUXyJtCwz58M0+2q802p0Ad+lRmjplzqIP8PdHmag==}
     peerDependencies:
       '@cloudflare/workers-types': ^4.20241202.0
       '@hattip/core': ^0.0.49
@@ -1210,29 +1210,29 @@ packages:
       hono:
         optional: true
 
-  '@universal-middleware/elysia@0.3.2':
-    resolution: {integrity: sha512-V+gh4kHDzxLrdAqOiI5Er97nqKAvfxTaG9CK7xq2YdOnRtzf+KZw+vJ3qQaN8eNdIcGbzW8EzViY8bxME3qTXw==}
+  '@universal-middleware/elysia@0.3.3':
+    resolution: {integrity: sha512-3g7QZbGgcZCH/uq1vfQKZ/Efrvj3JiLMgk9lOWI2LD4BDZgeCFx7pmNdFVQflhkDmTLAtG+A7/DXFYGmm9LNhg==}
 
-  '@universal-middleware/express@0.3.2':
-    resolution: {integrity: sha512-65xWOpPHJKdN+t2/45S+WGwLjXz+6o3q6wZ2vMf5IUpYJVIDqU4uP4uEteyheU+/VPjfBmbjDZndUTnu05rGFA==}
+  '@universal-middleware/express@0.3.3':
+    resolution: {integrity: sha512-0ute6Vg/Lct1lHpSP+zCW8OiuV5HjAoPui8BreqzLEBhqTjEG8+6aP1k6k3ewKD4VpR5/QNGb6YKLpUo7Ow+Hg==}
 
-  '@universal-middleware/fastify@0.4.2':
-    resolution: {integrity: sha512-v6/AeTRdHSQVc0+KeqtD2fSJ1gWCDOcCjD3ZytanVrYsGgiADYIHgdXV7o5vtjIAstknclx9hQaheULR8qNYjQ==}
+  '@universal-middleware/fastify@0.4.3':
+    resolution: {integrity: sha512-ak0k2jd0QmboMIBbAVi+yINBaoev0+5+zam368+XCY9P4cSizzLhRJGCDieGDz3CrRCKhcHqJV6Z34unLFE8cQ==}
 
-  '@universal-middleware/h3@0.3.2':
-    resolution: {integrity: sha512-hoflEiinD4uIHoyV1Fd4Al8kMnsWcMS7ygyaA75Ku7v28NzbEALLbqTMAXmS4h7Uw6kgKyUewcpUajhvgNXBUw==}
+  '@universal-middleware/h3@0.3.3':
+    resolution: {integrity: sha512-/Ik0fkFXzDAyg5Fr9DU0XqpC121ZYO5QoOt1JQddlNk9I88MdtENxiJjpXnE3l5Bwn1esKXt7rSe//QQcRLsyw==}
 
-  '@universal-middleware/hattip@0.3.2':
-    resolution: {integrity: sha512-DKdaZLRCuRR7dYhaaMiyYUBCimAvesZjeNXpWQ8tEkI/iavcFcdrv/4HxOWDxKCmvBTyQeiKGKkutYgmN1saRA==}
+  '@universal-middleware/hattip@0.3.3':
+    resolution: {integrity: sha512-ra2HPZM63O1HB1JvUGTQOkZhSgpiZa7fj8YWX7Rl1rXrD6rBwoCZ7nvioHEnLCGbI1lvc62RakLf9Hd59X48sg==}
 
-  '@universal-middleware/hono@0.3.2':
-    resolution: {integrity: sha512-rp2aOTuj6K+IWbVieVkyMrR9zKdLy6tVhuazYYYB6iIQQvNyfKFQSPgOHIGfWSt3vSyBQqlEz+EskUabYhfNfg==}
+  '@universal-middleware/hono@0.3.3':
+    resolution: {integrity: sha512-pmQXIymg0RWIrBL0n3QSfjVNWWTLG0tip/aM8SOJp3vt+MDsNpmIsvvpGnfnZjdfKWZp+6npEAqPUsZsFrnquA==}
 
-  '@universal-middleware/vercel@0.3.2':
-    resolution: {integrity: sha512-gCN0ei6KmDUGEnVpdmvSFfdtZdCanbJ4jvBjIScxjEtXdIQ95F27SIP6Y/vh9A9s1qJxpkaVqIAYBVqpQGMCyw==}
+  '@universal-middleware/vercel@0.3.3':
+    resolution: {integrity: sha512-wQ7hN6W/QUYy1USiXbxSvd6yJ9Uw/9TbHaH2xvAV/dyg/VbLAUpbKCCW48ia1+repA9PWecrwtgxB03fC2EazA==}
 
-  '@universal-middleware/webroute@0.3.2':
-    resolution: {integrity: sha512-qeZNIkMk5hne/ytqlDQ4umEdSjHCZqoYR6IpI/2cl9uDzV7dGj7lhGlDg0cmWyQ+zYLtxoD0gmKRtcnwlKA1qQ==}
+  '@universal-middleware/webroute@0.3.3':
+    resolution: {integrity: sha512-F/v4n/Q2xVDYBrq1bGQ+3ry2WPQ6JrghVh/PSyi53y3NuhJ7im3Pv4XiCnc7s7qhOW3pEsIPje1iEZDPLCeeKQ==}
 
   '@vercel/nft@0.26.5':
     resolution: {integrity: sha512-NHxohEqad6Ra/r4lGknO52uc/GrWILXAMs1BB4401GTqww0fw1bAqzpG1XHuDO+dprg4GvsD9ZLLSsdo78p9hQ==}
@@ -2907,8 +2907,8 @@ packages:
   unenv@1.10.0:
     resolution: {integrity: sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==}
 
-  universal-middleware@0.5.3:
-    resolution: {integrity: sha512-a0vwSY8lM5u19kzErfsk3URNwd/Vw7pE/M0VU6CW+3YZ92tLzeKH3j+7722gJ8xANnPlbHGX25/+2AqrQ8BeFA==}
+  universal-middleware@0.5.5:
+    resolution: {integrity: sha512-vgFODCngbqSiM4PLsfh+vRSXxSd4MQC/Zx4jzz79lmOcGsYLbW98uXYDOm+zVijb0rYFi4hkuMCvE4xWzRT3Mg==}
     peerDependencies:
       '@rollup/plugin-commonjs': ^28.0.1
       '@rollup/plugin-node-resolve': ^15.3.0
@@ -3902,9 +3902,9 @@ snapshots:
       '@types/node': 20.17.7
       '@types/send': 0.17.4
 
-  '@universal-middleware/cloudflare@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/cloudflare@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3914,9 +3914,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/compress@0.2.6': {}
+  '@universal-middleware/compress@0.2.8': {}
 
-  '@universal-middleware/core@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/core@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
       regexparam: 3.0.0
       tough-cookie: 5.0.0
@@ -3926,9 +3926,9 @@ snapshots:
       h3: 1.13.0
       hono: 4.6.12
 
-  '@universal-middleware/elysia@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/elysia@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3938,9 +3938,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/express@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/express@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3950,10 +3950,10 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/fastify@0.4.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/fastify@0.4.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/express': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/express': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
       fastify-raw-body: 5.0.0
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -3964,9 +3964,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/h3@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/h3@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3976,9 +3976,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/hattip@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/hattip@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3988,9 +3988,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/hono@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/hono@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -4000,10 +4000,10 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/vercel@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/vercel@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/express': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/express': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -4013,9 +4013,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/webroute@0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
+  '@universal-middleware/webroute@0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)':
     dependencies:
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -5739,18 +5739,18 @@ snapshots:
       node-fetch-native: 1.6.4
       pathe: 1.1.2
 
-  universal-middleware@0.5.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(esbuild@0.24.0)(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)(vite@6.0.2(@types/node@20.17.7)):
+  universal-middleware@0.5.5(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(esbuild@0.24.0)(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)(vite@6.0.2(@types/node@20.17.7)):
     dependencies:
-      '@universal-middleware/cloudflare': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/core': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/elysia': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/express': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/fastify': 0.4.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/h3': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/hattip': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/hono': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/vercel': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
-      '@universal-middleware/webroute': 0.3.2(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/cloudflare': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/core': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/elysia': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/express': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/fastify': 0.4.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/h3': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/hattip': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/hono': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/vercel': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
+      '@universal-middleware/webroute': 0.3.3(elysia@1.1.25(@sinclair/typebox@0.34.8)(typescript@5.7.2))(fastify@4.28.1)(h3@1.13.0)(hono@4.6.12)
       oxc-transform: 0.39.0
       package-up: 5.0.0
       unplugin: 2.0.0

--- a/test/vike-node/.testRun.ts
+++ b/test/vike-node/.testRun.ts
@@ -11,6 +11,8 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run prod') {
     expect(html).toContain('<h1>To-do List</h1>')
     expect(html).toContain('<li>Buy milk</li>')
     expect(html).toContain('<li>Buy strawberries</li>')
+    // provided through pageContext function
+    expect(html).toContain('x-runtime')
   })
 
   test('Add to-do item', async () => {

--- a/test/vike-node/pages/index/+Page.tsx
+++ b/test/vike-node/pages/index/+Page.tsx
@@ -1,15 +1,16 @@
 export default Page
 
+import type { Todo } from '@prisma/client'
 import React, { useState } from 'react'
 import { TodoList } from './TodoList'
-import type { Todo } from '@prisma/client'
 
-function Page({ todoItemsInitial }: { todoItemsInitial: Todo[] }) {
+function Page({ todoItemsInitial, xRuntime }: { todoItemsInitial: Todo[]; xRuntime?: string }) {
   return (
     <>
       <h1>To-do List</h1>
       <TodoList todoItemsInitial={todoItemsInitial} />
       <Counter />
+      {xRuntime}
     </>
   )
 }

--- a/test/vike-node/pages/index/+onBeforeRender.ts
+++ b/test/vike-node/pages/index/+onBeforeRender.ts
@@ -9,7 +9,8 @@ const onBeforeRender: OnBeforeRenderAsync = async (pageContext): ReturnType<OnBe
   return {
     pageContext: {
       pageProps: {
-        todoItemsInitial
+        todoItemsInitial,
+        xRuntime: pageContext.xRuntime
       }
     }
   }

--- a/test/vike-node/renderer/types.ts
+++ b/test/vike-node/renderer/types.ts
@@ -8,6 +8,7 @@ declare global {
   namespace Vike {
     interface PageContext {
       Page: Page
+      xRuntime?: string
       pageProps?: PageProps
     }
   }

--- a/test/vike-node/server/index-elysia.ts
+++ b/test/vike-node/server/index-elysia.ts
@@ -1,13 +1,13 @@
 import { Elysia } from 'elysia'
 import { telefunc } from 'telefunc'
-import vike from 'vike-node/elysia'
+import vike, { RuntimeAdapter } from 'vike-node/elysia'
 import { init } from '../database/todoItems'
 
 startServer()
 
 async function startServer() {
   await init()
-  const app = new Elysia()
+  const app = new Elysia().state('xRuntime', 'x-runtime')
 
   const port = process.env.PORT || 3000
   app.post('/_telefunc', async (ctx) => {
@@ -26,6 +26,15 @@ async function startServer() {
     ctx.set.headers['x-test'] = 'test'
   })
 
-  app.get('/*', vike())
+  app.get(
+    '/*',
+    vike({
+      pageContext(runtime: RuntimeAdapter) {
+        return {
+          xRuntime: (runtime.elysia.store as { xRuntime: string }).xRuntime
+        }
+      }
+    })
+  )
   app.listen(+port, () => console.log(`Server running at http://localhost:${port}`))
 }

--- a/test/vike-node/server/index-express.ts
+++ b/test/vike-node/server/index-express.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { telefunc } from 'telefunc'
-import vike, { RuntimeAdapter } from 'vike-node/express'
+import vike, { type RuntimeAdapter } from 'vike-node/express'
 import { Worker } from 'worker_threads'
 import { init } from '../database/todoItems.js'
 import { two } from './shared-chunk.js'
@@ -21,10 +21,19 @@ async function startServer() {
     res.status(statusCode).type(contentType).send(body)
   })
   app.use((req, res, next) => {
+    ;(req as any).xRuntime = 'x-runtime'
     res.set('x-test', 'test')
     next()
   })
-  app.use(vike())
+  app.use(
+    vike({
+      pageContext(runtime: RuntimeAdapter) {
+        return {
+          xRuntime: (runtime.req as any).xRuntime
+        }
+      }
+    })
+  )
   const port = process.env.PORT || 3000
   app.listen(port)
   console.log(`Server running at http://localhost:${port}`)

--- a/test/vike-node/server/index-express.ts
+++ b/test/vike-node/server/index-express.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { telefunc } from 'telefunc'
-import vike from 'vike-node/express'
+import vike, { RuntimeAdapter } from 'vike-node/express'
 import { Worker } from 'worker_threads'
 import { init } from '../database/todoItems.js'
 import { two } from './shared-chunk.js'

--- a/test/vike-node/server/index-h3.ts
+++ b/test/vike-node/server/index-h3.ts
@@ -1,7 +1,7 @@
-import { createApp, createRouter, eventHandler, toNodeListener, toWebRequest } from 'h3'
 import { createServer } from 'http'
+import { createApp, createRouter, eventHandler, toNodeListener, toWebRequest } from 'h3'
 import { telefunc } from 'telefunc'
-import vike from 'vike-node/h3'
+import vike, { RuntimeAdapter } from 'vike-node/h3'
 import { init } from '../database/todoItems'
 
 startServer()
@@ -38,11 +38,20 @@ async function startServer() {
 
   app.use(
     eventHandler((event) => {
+      event.context.xRuntime = 'x-runtime'
       event.node.res.setHeader('x-test', 'test')
     })
   )
 
-  app.use(vike())
+  app.use(
+    vike({
+      pageContext(runtime: RuntimeAdapter) {
+        return {
+          xRuntime: runtime.h3.context.xRuntime
+        }
+      }
+    })
+  )
 
   const server = createServer(toNodeListener(app)).listen(port)
 


### PR DESCRIPTION
- user provided context via function was always overridden by `universal-middleware` context
- adapter specific `RuntimeAdapter` type is available and can be used directly in `pageContext` function (see updated README)