### PR TITLE
Compare only the URL path component to expected value when proxying HMR websocket

### DIFF
--- a/examples/express-react-vercel/package.json
+++ b/examples/express-react-vercel/package.json
@@ -13,7 +13,7 @@
     "vike": "^0.4.219",
     "vike-node": "^0.3.1",
     "vike-react": "^0.5.7",
-    "vite": "^5.4.8"
+    "vite": "^5.4.12"
   },
   "type": "module"
 }

--- a/examples/express-react/package.json
+++ b/examples/express-react/package.json
@@ -12,7 +12,7 @@
     "vike": "^0.4.219",
     "vike-node": "^0.3.1",
     "vike-react": "^0.5.7",
-    "vite": "^5.4.8"
+    "vite": "^5.4.12"
   },
   "type": "module"
 }

--- a/examples/hono-react-cf-pages/package.json
+++ b/examples/hono-react-cf-pages/package.json
@@ -15,7 +15,7 @@
     "vike": "^0.4.219",
     "vike-node": "^0.3.1",
     "vike-react": "^0.5.7",
-    "vite": "^5.4.8"
+    "vite": "^5.4.12"
   },
   "type": "module",
   "devDependencies": {

--- a/examples/hono-react-vercel-edge/package.json
+++ b/examples/hono-react-vercel-edge/package.json
@@ -17,7 +17,7 @@
     "vike": "^0.4.219",
     "vike-node": "^0.3.1",
     "vike-react": "^0.5.7",
-    "vite": "^5.4.8",
+    "vite": "^5.4.12",
     "telefunc": "^0.1.76"
   },
   "type": "module"

--- a/packages/vike-node/package.json
+++ b/packages/vike-node/package.json
@@ -89,7 +89,7 @@
   },
   "peerDependencies": {
     "vike": "^0.4.213",
-    "vite": ">=5.0.10"
+    "vite": ">=5.4.12"
   },
   "devDependencies": {
     "@brillout/release-me": "^0.4.0",
@@ -102,7 +102,7 @@
     "typescript": "^5.5.4",
     "universal-middleware": "^0.5.5",
     "vike": "^0.4.219",
-    "vite": "^6.0.2"
+    "vite": "^6.0.9"
   },
   "files": [
     "dist/"

--- a/packages/vike-node/src/plugin/plugins/devServerPlugin.ts
+++ b/packages/vike-node/src/plugin/plugins/devServerPlugin.ts
@@ -114,13 +114,18 @@ export function devServerPlugin(): Plugin {
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     const server = (req.socket as any).server as Server
     server.on('upgrade', (clientReq, clientSocket, wsHead) => {
-      if (clientReq.url === VITE_HMR_PATH) {
+      if (isHMRProxyRequest(clientReq)) {
         assert(HMRServer)
         HMRServer.emit('upgrade', clientReq, clientSocket, wsHead)
       }
     })
     // true if we need to send an empty Response waiting for the upgrade
-    return req.url === VITE_HMR_PATH
+    return isHMRProxyRequest(req)
+  }
+
+  function isHMRProxyRequest(req: IncomingMessage) {
+    const url = new URL(`http://example.com${req.url}`)
+    return url.pathname === VITE_HMR_PATH
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.10))
+        version: 4.3.4(vite@5.4.14(@types/node@20.17.10))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -44,22 +44,22 @@ importers:
         version: 18.3.1(react@18.3.1)
       vike:
         specifier: ^0.4.219
-        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10))
+        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10))
       vike-node:
         specifier: link:../../packages/vike-node
         version: link:../../packages/vike-node
       vike-react:
         specifier: ^0.5.7
-        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10)))
+        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10)))
       vite:
-        specifier: ^5.4.8
-        version: 5.4.11(@types/node@20.17.10)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@20.17.10)
 
   examples/express-react-vercel:
     dependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.10))
+        version: 4.3.4(vite@5.4.14(@types/node@20.17.10))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -74,16 +74,16 @@ importers:
         version: 18.3.1(react@18.3.1)
       vike:
         specifier: ^0.4.219
-        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10))
+        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10))
       vike-node:
         specifier: link:../../packages/vike-node
         version: link:../../packages/vike-node
       vike-react:
         specifier: ^0.5.7
-        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10)))
+        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10)))
       vite:
-        specifier: ^5.4.8
-        version: 5.4.11(@types/node@20.17.10)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@20.17.10)
 
   examples/hono-react-cf-pages:
     dependencies:
@@ -92,7 +92,7 @@ importers:
         version: 1.13.7(hono@4.6.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.10))
+        version: 4.3.4(vite@5.4.14(@types/node@20.17.10))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -107,16 +107,16 @@ importers:
         version: 18.3.1(react@18.3.1)
       vike:
         specifier: ^0.4.219
-        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10))
+        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10))
       vike-node:
         specifier: link:../../packages/vike-node
         version: link:../../packages/vike-node
       vike-react:
         specifier: ^0.5.7
-        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10)))
+        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10)))
       vite:
-        specifier: ^5.4.8
-        version: 5.4.11(@types/node@20.17.10)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@20.17.10)
     devDependencies:
       telefunc:
         specifier: ^0.1.76
@@ -132,7 +132,7 @@ importers:
         version: 1.13.7(hono@4.6.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.10))
+        version: 4.3.4(vite@5.4.14(@types/node@20.17.10))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -150,16 +150,16 @@ importers:
         version: 0.1.82(@babel/core@7.26.0)(@babel/parser@7.26.3)(@babel/types@7.26.3)(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       vike:
         specifier: ^0.4.219
-        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10))
+        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10))
       vike-node:
         specifier: link:../../packages/vike-node
         version: link:../../packages/vike-node
       vike-react:
         specifier: ^0.5.7
-        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10)))
+        version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10)))
       vite:
-        specifier: ^5.4.8
-        version: 5.4.11(@types/node@20.17.10)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@20.17.10)
 
   packages/vike-node:
     dependencies:
@@ -217,13 +217,13 @@ importers:
         version: 5.7.2
       universal-middleware:
         specifier: ^0.5.5
-        version: 0.5.5(elysia@1.2.0(@sinclair/typebox@0.34.13)(typescript@5.7.2))(esbuild@0.24.2)(fastify@5.2.1)(h3@1.13.0)(hono@4.6.14)(rollup@4.29.1)(vite@6.0.5(@types/node@20.17.10))
+        version: 0.5.5(elysia@1.2.0(@sinclair/typebox@0.34.13)(typescript@5.7.2))(esbuild@0.24.2)(fastify@5.2.1)(h3@1.13.0)(hono@4.6.14)(rollup@4.29.1)(vite@6.0.11(@types/node@20.17.10))
       vike:
         specifier: ^0.4.219
-        version: 0.4.219(react-streaming@0.3.44)(vite@6.0.5(@types/node@20.17.10))
+        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.11(@types/node@20.17.10))
       vite:
-        specifier: ^6.0.2
-        version: 6.0.5(@types/node@20.17.10)
+        specifier: ^6.0.9
+        version: 6.0.11(@types/node@20.17.10)
 
   test/vike-node:
     dependencies:
@@ -250,7 +250,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.10))
+        version: 4.3.4(vite@5.4.14(@types/node@20.17.10))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -289,13 +289,13 @@ importers:
         version: 5.7.2
       vike:
         specifier: ^0.4.219
-        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10))
+        version: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10))
       vike-node:
         specifier: link:../../packages/vike-node
         version: link:../../packages/vike-node
       vite:
-        specifier: ^5.4.8
-        version: 5.4.11(@types/node@20.17.10)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@20.17.10)
 
 packages:
 
@@ -3045,8 +3045,8 @@ packages:
       vite:
         optional: true
 
-  vite@5.4.11:
-    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+  vite@5.4.14:
+    resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3076,8 +3076,8 @@ packages:
       terser:
         optional: true
 
-  vite@6.0.5:
-    resolution: {integrity: sha512-akD5IAH/ID5imgue2DYhzsEwCi0/4VKY31uhMLEYJwPP4TiUp8pL5PIK+Wo7H8qT8JY9i+pVfPydcFPYD1EL7g==}
+  vite@6.0.11:
+    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -4140,14 +4140,14 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@20.17.10))':
+  '@vitejs/plugin-react@4.3.4(vite@5.4.14(@types/node@20.17.10))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@20.17.10)
+      vite: 5.4.14(@types/node@20.17.10)
     transitivePeerDependencies:
       - supports-color
 
@@ -5912,7 +5912,7 @@ snapshots:
       node-fetch-native: 1.6.4
       pathe: 1.1.2
 
-  universal-middleware@0.5.5(elysia@1.2.0(@sinclair/typebox@0.34.13)(typescript@5.7.2))(esbuild@0.24.2)(fastify@5.2.1)(h3@1.13.0)(hono@4.6.14)(rollup@4.29.1)(vite@6.0.5(@types/node@20.17.10)):
+  universal-middleware@0.5.5(elysia@1.2.0(@sinclair/typebox@0.34.13)(typescript@5.7.2))(esbuild@0.24.2)(fastify@5.2.1)(h3@1.13.0)(hono@4.6.14)(rollup@4.29.1)(vite@6.0.11(@types/node@20.17.10)):
     dependencies:
       '@universal-middleware/cloudflare': 0.3.3(elysia@1.2.0(@sinclair/typebox@0.34.13)(typescript@5.7.2))(fastify@5.2.1)(h3@1.13.0)(hono@4.6.14)
       '@universal-middleware/core': 0.3.3(elysia@1.2.0(@sinclair/typebox@0.34.13)(typescript@5.7.2))(fastify@5.2.1)(h3@1.13.0)(hono@4.6.14)
@@ -5930,7 +5930,7 @@ snapshots:
     optionalDependencies:
       esbuild: 0.24.2
       rollup: 4.29.1
-      vite: 6.0.5(@types/node@20.17.10)
+      vite: 6.0.11(@types/node@20.17.10)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -5964,14 +5964,14 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vike-react@0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10))):
+  vike-react@0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10))):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-streaming: 0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      vike: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10))
+      vike: 0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10))
 
-  vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@20.17.10)):
+  vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.10)):
     dependencies:
       '@brillout/import': 0.2.3
       '@brillout/json-serializer': 0.5.15
@@ -5988,9 +5988,9 @@ snapshots:
       source-map-support: 0.5.21
     optionalDependencies:
       react-streaming: 0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      vite: 5.4.11(@types/node@20.17.10)
+      vite: 5.4.14(@types/node@20.17.10)
 
-  vike@0.4.219(react-streaming@0.3.44)(vite@6.0.5(@types/node@20.17.10)):
+  vike@0.4.219(react-streaming@0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.11(@types/node@20.17.10)):
     dependencies:
       '@brillout/import': 0.2.3
       '@brillout/json-serializer': 0.5.15
@@ -6007,9 +6007,9 @@ snapshots:
       source-map-support: 0.5.21
     optionalDependencies:
       react-streaming: 0.3.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      vite: 6.0.5(@types/node@20.17.10)
+      vite: 6.0.11(@types/node@20.17.10)
 
-  vite@5.4.11(@types/node@20.17.10):
+  vite@5.4.14(@types/node@20.17.10):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.4.49
@@ -6018,7 +6018,7 @@ snapshots:
       '@types/node': 20.17.10
       fsevents: 2.3.3
 
-  vite@6.0.5(@types/node@20.17.10):
+  vite@6.0.11(@types/node@20.17.10):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.4.49

--- a/test/vike-node/package.json
+++ b/test/vike-node/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.5.4",
     "vike": "^0.4.219",
     "vike-node": "link:../../packages/vike-node",
-    "vite": "^5.4.8"
+    "vite": "^5.4.12"
   },
   "type": "module"
 }


### PR DESCRIPTION
In versions [5.4.12](https://github.com/vitejs/vite/compare/v5.4.11...v5.4.12) and [6.0.9](https://github.com/vitejs/vite/compare/v6.0.8...v6.0.9) vite introduced several fixes to [vulnerabilities in HMR websocket](https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6).

Amongst other changes, a query parameter `token` was added to the HMR websocket upgrade request.
This broke the HMR proxy feature in`vike-node`. Socket connection was not established, and the browser request was left pending until timing out.

This PR suggests a backwards compatible approach to accommodate these changes.

Following steps were taken:

- Edit `devServerPlugin.ts`
- Edit `vite`dependencies to the minimum patch version with the aforementioned security fixes in all `package.json` -files
- Run `pnpm install && pnpm run build && pnpm run test` and confirm successful run
- Revert to original `package.json` -files and run `pnpm run reset && pnpm install && pnpm run build && pnpm run test` to confirm successful run with previously used `vite` versions

`package.json` modifications are not necessary to fix the issue, but are included for replicating the steps above 