### PR TITLE
fix: load handleViteDevServer adapter only in dev

### DIFF
--- a/packages/vike-node/src/runtime/adapters/handleViteDevServer.ts
+++ b/packages/vike-node/src/runtime/adapters/handleViteDevServer.ts
@@ -1,0 +1,16 @@
+export { handleViteDevServer }
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { assert } from '../../utils/assert.js'
+import { globalStore } from '../globalStore.js'
+
+function handleViteDevServer(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    res.once('close', () => {
+      resolve(true)
+    })
+    assert(globalStore.viteDevServer)
+    globalStore.viteDevServer.middlewares(req, res, () => {
+      resolve(false)
+    })
+  })
+}

--- a/packages/vike-node/src/runtime/vike-handler.ts
+++ b/packages/vike-node/src/runtime/vike-handler.ts
@@ -2,7 +2,6 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import compressMiddlewareFactory from '@universal-middleware/compress'
 import type { Get, RuntimeAdapter, UniversalHandler, UniversalMiddleware } from '@universal-middleware/core'
 import { renderPage as _renderPage } from 'vike/server'
-import { assert } from '../utils/assert.js'
 import { isVercel } from '../utils/isVercel.js'
 import { connectToWeb } from './adapters/connectToWeb.js'
 import { globalStore } from './globalStore.js'
@@ -76,8 +75,8 @@ export const renderPageHandler = ((options?) => async (request, context, runtime
   }
 
   if (globalStore.isDev) {
-    const handled = await web(request)
-
+    const { handleViteDevServer } = await import('./adapters/handleViteDevServer.js')
+    const handled = await connectToWeb(handleViteDevServer)(request)
     if (handled) return handled
   } else if (nodeReq) {
     if (staticConfig) {
@@ -116,17 +115,3 @@ export const renderPageHandler = ((options?) => async (request, context, runtime
     headers: response.headers
   })
 }) satisfies Get<[options: VikeOptions], UniversalHandler>
-
-const web = connectToWeb(handleViteDevServer)
-
-function handleViteDevServer(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
-    res.once('close', () => {
-      resolve(true)
-    })
-    assert(globalStore.viteDevServer)
-    globalStore.viteDevServer.middlewares(req, res, () => {
-      resolve(false)
-    })
-  })
-}


### PR DESCRIPTION
Use dynamic import for `handleViteDevServer`. By this way the `handleViteDevServer` will not be bundled.

Partial of #51