### PR TITLE
fix: avoid Vite type version mismatch

### DIFF
--- a/packages/vike-server/src/plugin/index.ts
+++ b/packages/vike-server/src/plugin/index.ts
@@ -4,13 +4,17 @@ import { commonConfig } from './plugins/commonConfig.js'
 import { devServerPlugin } from './plugins/devServerPlugin.js'
 import { serverEntryPlugin } from './plugins/serverEntryPlugin.js'
 import { standalonePlugin } from './plugins/standalonePlugin.js'
+import type { Plugin } from 'vite'
 
-function vikeServer() {
-  return [
+type PluginInterop = Record<string, unknown> & { name: string }
+// Return `PluginInterop` instead of `Plugin` to avoid type mismatch upon different Vite versions
+function vikeServer(): PluginInterop[] {
+  const plugins: Plugin[] = [
     //
     ...commonConfig(),
     ...serverEntryPlugin(),
     devServerPlugin(),
     standalonePlugin()
   ]
+  return plugins as any
 }


### PR DESCRIPTION
(@magne4000 I think in this situation, this is a good solution. Feel free to disagree.)